### PR TITLE
Fix gtg-check workflow race condition

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,6 +6,13 @@ on:
     workflows: ["Tests & Quality"]
     types: [completed]
 
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  pull-requests: read
+  statuses: write
+
 jobs:
   gtg-check:
     # Only run on pull requests (not direct pushes to main)


### PR DESCRIPTION
## Summary

- Restructure pr-check.yml to use `workflow_run` trigger instead of running in parallel
- gtg-check now runs only after Tests & Quality workflow completes
- Adds commit status posting to make gtg-check visible in PR checks

## Problem

The gtg-check workflow was running in parallel with other CI checks, causing it to always report `CI_FAILING` because the other checks hadn't completed yet.

## Solution

Use `workflow_run` trigger to run gtg-check after the Tests & Quality workflow completes:

```yaml
on:
  workflow_run:
    workflows: ["Tests & Quality"]
    types: [completed]
```

Key changes:
1. **Trigger**: Changed from `pull_request` to `workflow_run` completion
2. **PR number extraction**: Uses GitHub API to get PR number from the triggering workflow
3. **Commit status**: Posts a status check to make gtg result visible in PR
4. **Filter**: Only runs on `pull_request` events (skips direct pushes to main)

## Test Plan

- [ ] Create a test PR and verify gtg-check runs after Tests & Quality completes
- [ ] Verify gtg-check shows correct status (READY when all pass)
- [ ] Verify commit status appears in PR checks

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)